### PR TITLE
Update validation

### DIFF
--- a/validation/eyeriss/alexnet_rs_validation.m
+++ b/validation/eyeriss/alexnet_rs_validation.m
@@ -50,6 +50,8 @@ Dimensions { N 4, K 384, C 256, R 3, S 3, Y 15, X 15 }
     TemporalMap(4,4) C;
     TemporalMap(13,13) Y';
     TemporalMap(15,13) X;
+    TemporalMap(Sz(R),Sz(R)) R;
+    TemporalMap(Sz(S),Sz(S)) S;    
     Cluster(13, P);
     TemporalMap(4,4) N;
     TemporalMap(16,16) K;
@@ -86,6 +88,8 @@ Dimensions { N 4, K 384,C 192, R 3, S 3, Y 15, X 15 }
     TemporalMap(16,16) K;
     TemporalMap(13,13) Y';
     TemporalMap(1,1) X';    
+    TemporalMap(Sz(R),Sz(R)) R;
+    TemporalMap(Sz(S),Sz(S)) S;     
     Cluster(13, P);
     TemporalMap(4,4) N;
     TemporalMap(3,3) C;

--- a/validation/eyeriss/run_eval_alexnet_rs.sh
+++ b/validation/eyeriss/run_eval_alexnet_rs.sh
@@ -3,7 +3,7 @@
           --print_res=true \
           --print_res_csv_file=true \
           --print_log_file=false \
-             --noc_bw=1000000000 \
+          --noc_bw=14 \
           --noc_hop_latency=1 \
           --noc_mc_support=true \
           --num_pes=168 \


### PR DESCRIPTION
* Updated alexnet_rs_validation.m
  * Added directives on R and S dimensions since [these variables in `ConvertToInputCentric`](https://github.com/maestro-project/maestro/blob/af17083a12a910dceb963be22f72a124556cff10/cost-model/include/dataflow-analysis/DFA_cluster-analysis.hpp#L347) are intentionally not initialized.
* Adjusted the bandwidth to be 14
  * Modeled the upper bandwidth of Eyeriss's hierarchical bus to 14x12 PE array